### PR TITLE
use Bundler 2.0.0 final

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -16,7 +16,7 @@ class LanguagePack::Ruby < LanguagePack::Base
   NAME                 = "ruby"
   LIBYAML_VERSION      = "0.1.7"
   LIBYAML_PATH         = "libyaml-#{LIBYAML_VERSION}"
-  BUNDLER_VERSION      = "2.0.0.pre.2"
+  BUNDLER_VERSION      = "2.0.0"
   BUNDLER_GEM_PATH     = "bundler-#{BUNDLER_VERSION}"
   RBX_BASE_URL         = "http://binaries.rubini.us/heroku"
   NODE_BP_PATH         = "vendor/node/bin"


### PR DESCRIPTION
Heroku deploys broke for me because they use `2.0.0.pre.2`
and my Gemfile.lock now says `2.0.0`

```
-----> Ruby app detected
-----> Compiling Ruby/Rails
-----> Using Ruby version: ruby-2.6.0
-----> Installing dependencies using bundler 2.0.0.pre.2
       Running: bundle install --without development:test --path vendor/bundle --binstubs vendor/bundle/bin -j4 --deployment
       Activating bundler (2.0.0) failed:
       Could not find 'bundler' (2.0.0) required by your /tmp/build_b0e49a4077b0aacc4e82a4fc89828e98/Gemfile.lock.
       To update to the latest version installed on your system, run `bundle update --bundler`.
       To install the missing version, run `gem install bundler:2.0.0`
       Checked in 'GEM_PATH=/tmp/build_b0e49a4077b0aacc4e82a4fc89828e98/vendor/bundle/ruby/2.6.0', execute `gem env` for more information
       
       To install the version of bundler this project requires, run `gem install bundler -v '2.0.0'`
       Bundler Output: Activating bundler (2.0.0) failed:
       Could not find 'bundler' (2.0.0) required by your /tmp/build_b0e49a4077b0aacc4e82a4fc89828e98/Gemfile.lock.
       To update to the latest version installed on your system, run `bundle update --bundler`.
       To install the missing version, run `gem install bundler:2.0.0`
       Checked in 'GEM_PATH=/tmp/build_b0e49a4077b0aacc4e82a4fc89828e98/vendor/bundle/ruby/2.6.0', execute `gem env` for more information
       
       To install the version of bundler this project requires, run `gem install bundler -v '2.0.0'`
 !
 !     Failed to install gems via Bundler.
 !
 !     Push rejected, failed to compile Ruby app.
 !     Push failed
```