### PR TITLE
Update compile

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,11 +1,4 @@
 #!/bin/bash
-# The actual `bin/compile` code lives in `bin/support/ruby_compile`. This file
-# instead bootstraps the ruby needed and then executes `bin/support/ruby_compile`
 
-BIN_DIR=$(cd $(dirname $0); pwd)
-BUILDPACK_DIR=$(dirname $BIN_DIR)
-
-source "$BIN_DIR/support/bash_functions.sh"
-heroku_buildpack_ruby_install_ruby "$BIN_DIR" "$BUILDPACK_DIR"
-
-$heroku_buildpack_ruby_dir/bin/ruby $BIN_DIR/support/ruby_compile $@
+echo "This buildpack is no longer supported, please use `heroku/ruby` which now supports Bundler 2 directly"
+exit 1


### PR DESCRIPTION
The `heroku/ruby` buildpack now supports Bundler 2 directly. Since this repo is archived, consumers should be directed to use the currently maintained `heroku/ruby` buildpack.